### PR TITLE
Changes the marshalling of arguments to preserve arguments with self

### DIFF
--- a/rdfscript/expansion.py
+++ b/rdfscript/expansion.py
@@ -1,4 +1,4 @@
-from rdfscript.core import Argument, Identifier, Name, Node, Self, Uri, Parameter
+from rdfscript.core import Argument, Node, Self, Parameter
 from rdfscript.pragma import ExtensionPragma
 from rdfscript.error import TemplateNotFound
 
@@ -18,7 +18,7 @@ class Expansion(Node):
             else:
                 self.args.append(Argument(arg, n, location))
 
-        self.args.append(Argument(self.identifier, -1))
+        self.args.insert(0, Argument(self.identifier, -1))
 
         self.extensions = []
         self.body = []

--- a/test/rdfscript/test_template.py
+++ b/test/rdfscript/test_template.py
@@ -576,6 +576,24 @@ class TemplateClassTest(unittest.TestCase):
 
         self.assertCountEqual(found, expect)
 
+    def test_scoping_of_self(self):
+        forms = self.parser.parse(('a(param)(p=param)'
+                                   'b()(d is a a(self.t1))'))
+        a = forms[0]
+        b = forms[1]
+        with self.assertRaises(KeyError):
+            self.env.lookup_template(b.identifier.evaluate(self.env))
+
+        a.evaluate(self.env)
+        b.evaluate(self.env)
+
+        found = self.env.lookup_template(b.identifier.evaluate(self.env))
+        expect = [(Identifier(Name('d')).evaluate(self.env),
+                   Identifier(Name('p')).evaluate(self.env),
+                   Identifier(Self(), Name('t1')))]
+
+        self.assertCountEqual(found, expect)
+
     def test_evaluate_to_template_name(self):
         forms = self.parser.parse('t()(x=1 y=2)')
         t = forms[0]


### PR DESCRIPTION
Addresses issue#15 by inserting the 'self' argument to an expansion's
argument list instead of appending. This solution might be quite
fragile, a more long-term solution might be to add a flag indicating
whether or not a parameter has already been substituted, for example,
or to rewrite the definition of Self class to include this flag.